### PR TITLE
neovim: add nvim-tree

### DIFF
--- a/neovim/.config/nvim/after/plugin/nvim_tree.lua
+++ b/neovim/.config/nvim/after/plugin/nvim_tree.lua
@@ -1,0 +1,25 @@
+-- disable netrw at the very start of your init.lua
+vim.g.loaded_netrw = 1
+vim.g.loaded_netrwPlugin = 1
+
+-- optionally enable 24-bit colour
+vim.opt.termguicolors = true
+
+-- empty setup using defaults
+require("nvim-tree").setup()
+
+-- OR setup with some options
+require("nvim-tree").setup({
+  sort = {
+    sorter = "case_sensitive",
+  },
+  view = {
+    width = 30,
+  },
+  renderer = {
+    group_empty = true,
+  },
+  filters = {
+    dotfiles = true,
+  },
+})

--- a/neovim/.config/nvim/lua/leonampd/packer.lua
+++ b/neovim/.config/nvim/lua/leonampd/packer.lua
@@ -78,4 +78,11 @@ return require('packer').startup(function(use)
 
     use {'hrsh7th/vim-vsnip'}
     use {'lfv89/vim-interestingwords'}
+
+    use {
+        'nvim-tree/nvim-tree.lua',
+        requires = {
+            'nvim-tree/nvim-web-devicons', -- optional
+        },
+    }
 end)


### PR DESCRIPTION
This pull request includes changes to the Neovim configuration to add and configure the `nvim-tree` plugin. The changes involve disabling netrw, enabling 24-bit color, setting up `nvim-tree` with specific options, and adding the necessary plugin dependencies.

### Plugin Configuration:

* [`neovim/.config/nvim/after/plugin/nvim_tree.lua`](diffhunk://#diff-4bf3b0600bc7f9417bdfcc93da6dce145d9f8250bd68e27b5fc24bf9cf2eea92R1-R25): Disabled netrw, enabled 24-bit color, and set up `nvim-tree` with options such as case-sensitive sorting, a view width of 30, grouping empty directories, and filtering dotfiles.

### Plugin Dependencies:

* [`neovim/.config/nvim/lua/leonampd/packer.lua`](diffhunk://#diff-e7d2c16c08309beef2c91a7101a3761f6776f37ead0750e8b254fee860e86346R81-R87): Added `nvim-tree` and its optional dependency `nvim-web-devicons` to the list of plugins managed by Packer.